### PR TITLE
Compare players interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .vscode
+node_modules
+package-lock.json

--- a/ia/quatro.pl
+++ b/ia/quatro.pl
@@ -19,7 +19,7 @@
 
 :- dynamic remainingPieces/1.
 
-reset():- retract(boardSize(_)), retract(boardColor(_)), retract(boardShape(_)), retract(boardHole(_)), retract(remainingPieces(_)).
+reset():- halt, retract(boardSize(_)), retract(boardColor(_)), retract(boardShape(_)), retract(boardHole(_)), retract(remainingPieces(_)).
 %TODO Le cas ou le board est plein et il n'y a pas de gagnant n'est pas pris en compte.
 play(Player):- gameover(), write('Game is Over. Winner: '), writeln(Player),boardSize(BoardSize), boardShape(BoardShape), boardHole(BoardHole), boardColor(BoardColor), displayBoard(BoardSize, BoardShape, BoardHole, BoardColor), reset().
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,62 @@
+const electron = require('electron')
+// Module to control application life.
+const app = electron.app
+// Module to create native browser window.
+const BrowserWindow = electron.BrowserWindow
+
+const path = require('path')
+const url = require('url')
+
+// Keep a global reference of the window object, if you don't, the window will
+// be closed automatically when the JavaScript object is garbage collected.
+let mainWindow
+
+function createWindow () {
+  // Create the browser window.
+  mainWindow = new BrowserWindow({width: 800, height: 300})
+
+  // and load the index.html of the app.
+  mainWindow.loadURL(url.format({
+    pathname: path.join(__dirname, 'ui/index.html'),
+    protocol: 'file:',
+    slashes: true
+  }))
+
+  mainWindow.setMenu(null)
+
+  // Open the DevTools.
+  // mainWindow.webContents.openDevTools()
+
+  // Emitted when the window is closed.
+  mainWindow.on('closed', function () {
+    // Dereference the window object, usually you would store windows
+    // in an array if your app supports multi windows, this is the time
+    // when you should delete the corresponding element.
+    mainWindow = null
+  })
+}
+
+// This method will be called when Electron has finished
+// initialization and is ready to create browser windows.
+// Some APIs can only be used after this event occurs.
+app.on('ready', createWindow)
+
+// Quit when all windows are closed.
+app.on('window-all-closed', function () {
+  // On OS X it is common for applications and their menu bar
+  // to stay active until the user quits explicitly with Cmd + Q
+  if (process.platform !== 'darwin') {
+    app.quit()
+  }
+})
+
+app.on('activate', function () {
+  // On OS X it's common to re-create a window in the app when the
+  // dock icon is clicked and there are no other windows open.
+  if (mainWindow === null) {
+    createWindow()
+  }
+})
+
+// In this file you can include the rest of your app's specific main process
+// code. You can also put them in separate files and require them here.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "tp-alia",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "electron .",
+    "rebuild-modules": "electron-rebuild",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/IssouProjects/TP-ALIA.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/IssouProjects/TP-ALIA/issues"
+  },
+  "homepage": "https://github.com/IssouProjects/TP-ALIA#readme",
+  "dependencies": {
+    "electron": "^1.8.1"
+  },
+  "devDependencies": {
+    "electron-rebuild": "^1.6.0"
+  }
+}

--- a/ui/index.html
+++ b/ui/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <title>Player stats</title>
+  <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
+</head>
+
+<body>
+  <div class="container">
+  <h1>Players stats</h1>
+  <p>
+    Player 0
+    <div class="progress">
+      <div id="winner0" class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"><div id="wins0">0</div></div>
+    </div>
+  </p>
+  <p>
+    Player 1
+    <div class="progress">
+      <div id="winner1" class="progress-bar progress-bar-warning" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"><div id="wins1">0</div></div>
+    </div>
+  </p>
+  <button type="button" class="btn btn-primary" id="start">Go</button>
+  <button type="button" class="btn btn-danger" id="stop" disabled>Stop</button>
+  </div>
+</body>
+
+<script>
+  require('./renderer.js')
+</script>
+
+</html>

--- a/ui/prolog.js
+++ b/ui/prolog.js
@@ -1,0 +1,16 @@
+
+var execute = require('child_process').exec;
+
+module.exports.getOutput = function(callback) {
+  execute("swipl -s ia/quatro.pl -g init", function(error, stdout, stderr) {  
+    if(stdout.includes("Winner: 0")) {
+      callback(0)
+    }
+    else if(stdout.includes("Winner: 1")) {
+      callback(1)
+    }
+    else {
+      callback(-1)
+    }
+  })
+};

--- a/ui/renderer.js
+++ b/ui/renderer.js
@@ -1,0 +1,48 @@
+const prolog = require('./prolog');
+
+var winner0 = 0
+var winner1 = 0
+
+var stop = false
+
+function play(games) {
+  prolog.getOutput(function (winner) {
+    console.log("Games to play: " + games)
+    console.log(winner)
+    //winner = output.replace(/\n/g, "<br />");
+    if(winner == 0) {
+      winner0 ++
+    }
+    else if(winner == 1) {
+      winner1 ++
+    }
+
+    document.getElementById("winner0").style.width = winner0 + "%"
+    document.getElementById("winner1").style.width = winner1 + "%"
+    document.getElementById("wins0").innerHTML = winner0
+    document.getElementById("wins1").innerHTML = winner1
+    if(winner0 + winner1 < games && stop === false) {
+      play(games)
+    } else {
+      stop = false
+      done()
+    }
+  })
+}
+
+function done() {
+  document.getElementById("start").disabled = false
+  document.getElementById("stop").disabled = true
+}
+
+document.getElementById("start").addEventListener("click", function () {
+  winner0 = 0
+  winner1 = 0
+  document.getElementById("start").disabled = true
+  document.getElementById("stop").disabled = false
+  play(100)
+})
+
+document.getElementById("stop").addEventListener("click", function () {
+  stop = true
+})


### PR DESCRIPTION
Alors voilà de quoi avoir une interface pour comparer les performances des joueurs. Il donne le nombre de parties gagnées pour chaque joueur (il en fait 100).

Testez en faisant `npm install` puis `npm start` (il faut avoir NodeJS installé sur sa machine)

Je n'ai rien changé dans prolog, sauf un truc : le programme s'arrête à la fin d'une partie... J'en avais besoin pour être sûr de sortir de swipl après chaque partie

![image](https://user-images.githubusercontent.com/24607388/33244417-12ce8cb6-d2f7-11e7-8492-cc2334567de0.png)


